### PR TITLE
docs: fix typo in module name

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 ---
-name: "matallb"
+name: "metallb"
 title: "MetalLB Module"
 version: true
 start_page: README.adoc


### PR DESCRIPTION
## Description of the changes

This PR is to fix a typo in the module name, this breaks the link on the sidebar of the documenation, since we evidently point to the name `metallb` not `matallb` :)

We need to force a new release with `Release-As: v1.0.1` to see this change in the web interface, if we want to.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
