### PR TITLE
ci: add support for the chart auto-updater workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+# Use Dependabot to update GitHub Actions and the Terraform modules on our examples
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    # Check for updated GitHub Actions every week
+    interval: "weekly"

--- a/.github/workflows/chart-update.yaml
+++ b/.github/workflows/chart-update.yaml
@@ -1,0 +1,186 @@
+---
+name: "chart-update"
+
+on:
+  schedule:
+  - cron: "0 7 * * 1-5"
+  
+  workflow_dispatch:
+    inputs:
+      update-strategy:
+        description: "Update strategy to use. Valid values are 'patch', 'minor' or 'major'"
+        type: choice
+        options:
+        - "patch"
+        - "minor"
+        - "major"
+        required: true
+      excluded-dependencies:
+        description: "Comma-separated list of dependencies to exclude from the update (i.e. 'dependency1,dependency2,dependency3')"
+        type: string
+        required: false
+        default: ""
+      dry-run:
+        description: "Activate dry-run mode"
+        type: boolean
+        required: false
+        default: true
+
+# Define global settings for all the steps.
+env:
+  author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+
+# The duplication of code between the two steps is not ideal, but we did not find a way to reuse the centralized 
+# workflow or by using a strategy matrix to workaround the problem.
+jobs:
+  chart-update-schedule:
+    runs-on: ubuntu-latest
+    
+    if: ${{ github.event_name == 'schedule' }}
+
+    strategy:
+      matrix:
+        update-strategy: ["minor", "major"]
+
+    steps:
+    - name: "Check out the repository"
+      uses: actions/checkout@v3
+
+    - name: "Upgrade Helm chart dependencies"
+      id: deps-update
+      uses: camptocamp/helm-dependency-update-action@v0.4.1
+      with:
+        chart-path: "charts/metallb"
+        readme-path: "README.adoc"
+        update-strategy: "${{ matrix.update-strategy }}"
+
+    - name: "Extract the Chart.yaml file from the upgraded chart"
+      if: ${{ steps.deps-update.outputs.update-type != 'none' }}
+      run: |
+        rm -rf charts/metallb/charts/metallb
+        tar -zxvf charts/metallb/charts/metallb-*.tgz -C charts/metallb/charts
+
+    - name: "Create Pull Request for a minor/patch update"
+      if: ${{ steps.deps-update.outputs.update-type != 'none' && steps.deps-update.outputs.update-type != 'major' }}
+      id: minor-pr
+      uses: peter-evans/create-pull-request@v5
+      env:
+        pr-title: "feat(chart): ${{ steps.deps-update.outputs.update-type }} update of dependencies on metallb chart"
+        branch: "chart-autoupdate-${{ steps.deps-update.outputs.update-type }}-metallb"
+        labels: "chart-autoupdate-${{ steps.deps-update.outputs.update-type }}"
+      with:
+        commit-message: ${{ env.pr-title }}
+        author: ${{ env.author }}
+        committer: ${{ env.author }}
+        branch: "chart-autoupdate-${{ steps.deps-update.outputs.update-type }}-metallb"
+        title: ${{ env.pr-title }}
+        labels: "chart-autoupdate-${{ steps.deps-update.outputs.update-type }}"
+        body: |
+          :robot: I have updated the chart *beep* *boop*
+          ---
+
+          ## Description of the changes
+
+          This PR updates the dependencies of the **metallb** Helm chart.
+          
+          The maximum version bump was a **${{ steps.deps-update.outputs.update-type }}** step.
+
+    - name: "Create Pull Request for a major update"
+      if: ${{ steps.deps-update.outputs.update-type != 'none' && steps.deps-update.outputs.update-type == 'major' }}
+      id: major-pr
+      uses: peter-evans/create-pull-request@v5
+      env:
+        # This step does not have a branch and labels environment variable, because it is forcefully a major update, 
+        # unlike the previous step, which can either be a patch, minor or major update.
+        pr-title: "feat!(chart): major update of dependencies on metallb chart"
+      with:
+        commit-message: ${{ env.pr-title }}
+        author: ${{ env.author }}
+        committer: ${{ env.author }}
+        branch: "chart-autoupdate-major-metallb"
+        title: ${{ env.pr-title }}
+        labels: "chart-autoupdate-major"
+        body: |
+          :robot: I have updated the chart *beep* *boop*
+          ---
+
+          ## Description of the changes
+
+          This PR updates the dependencies of the **metallb** Helm chart. .
+
+          :warning: This was a **major** update! Please check the changelog of the updated dependencies and **take notice of any breaking changes before merging**. :warning:
+        
+  chart-update-manual:
+    runs-on: ubuntu-latest
+    
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+
+    steps:
+    - name: "Check out the repository"
+      uses: actions/checkout@v3
+
+    - name: "Upgrade Helm chart dependencies"
+      id: deps-update
+      uses: camptocamp/helm-dependency-update-action@v0.4.1
+      with:
+        chart-path: "charts/metallb"
+        readme-path: "README.adoc"
+        excluded-dependencies: ${{ inputs.excluded-dependencies }}
+        update-strategy: "${{ inputs.update-strategy }}"
+        dry-run: "${{ inputs.dry-run }}"
+
+    - name: "Extract the Chart.yaml file from the upgraded chart"
+      if: ${{ steps.deps-update.outputs.update-type != 'none' }}
+      run: |
+        rm -rf charts/metallb/charts/metallb
+        tar -zxvf charts/metallb/charts/metallb-*.tgz -C charts/metallb/charts
+
+    - name: "Create Pull Request for a minor/patch update"
+      if: ${{ !inputs.dry-run && steps.deps-update.outputs.update-type != 'none' && steps.deps-update.outputs.update-type != 'major' }}
+      id: minor-pr
+      uses: peter-evans/create-pull-request@v5
+      env:
+        pr-title: "feat(chart): ${{ steps.deps-update.outputs.update-type }} update of dependencies on metallb chart"
+        branch: "chart-autoupdate-${{ steps.deps-update.outputs.update-type }}-metallb"
+        labels: "chart-autoupdate-${{ steps.deps-update.outputs.update-type }}"
+      with:
+        commit-message: ${{ env.pr-title }}
+        author: ${{ env.author }}
+        committer: ${{ env.author }}
+        branch: "chart-autoupdate-${{ steps.deps-update.outputs.update-type }}-metallb"
+        title: ${{ env.pr-title }}
+        labels: "chart-autoupdate-${{ steps.deps-update.outputs.update-type }}"
+        body: |
+          :robot: I have updated the chart *beep* *boop*
+          ---
+
+          ## Description of the changes
+
+          This PR updates the dependencies of the **metallb** Helm chart.
+          
+          The maximum version bump was a **${{ steps.deps-update.outputs.update-type }}** step.
+
+    - name: "Create Pull Request for a major update"
+      if: ${{ !inputs.dry-run && steps.deps-update.outputs.update-type != 'none' && steps.deps-update.outputs.update-type == 'major' }}
+      id: major-pr
+      uses: peter-evans/create-pull-request@v5
+      env:
+        # This step does not have a branch and labels environment variable, because it is forcefully a major update, 
+        # unlike the previous step, which can either be a patch, minor or major update.
+        pr-title: "feat!(chart): major update of dependencies on metallb chart"
+      with:
+        commit-message: ${{ env.pr-title }}
+        author: ${{ env.author }}
+        committer: ${{ env.author }}
+        branch: "chart-autoupdate-major-metallb"
+        title: ${{ env.pr-title }}
+        labels: "chart-autoupdate-major"
+        body: |
+          :robot: I have updated the chart *beep* *boop*
+          ---
+
+          ## Description of the changes
+
+          This PR updates the dependencies of the **metallb** Helm chart. .
+
+          :warning: This was a **major** update! Please check the changelog of the updated dependencies and **take notice of any breaking changes before merging**. :warning:

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,5 @@
+:metallb-chart-version: 0.13.7
+
 // BEGIN_TF_DOCS
 === Requirements
 


### PR DESCRIPTION
## Description of the changes

Adds the chart autoupdater workflow that is specific to this module since we need to decompress the chart manually.

## Breaking change

- [x] No